### PR TITLE
10/EPMDX Review

### DIFF
--- a/0010-endpoint-metadata-extension/schemas/delete-metadata-key-response.schema.json
+++ b/0010-endpoint-metadata-extension/schemas/delete-metadata-key-response.schema.json
@@ -19,6 +19,7 @@
     }
   },
   "required": [
+    "id",
     "statusCode",
     "reasonPhrase"
   ],

--- a/0010-endpoint-metadata-extension/schemas/get-metadata-keys-request.schema.json
+++ b/0010-endpoint-metadata-extension/schemas/get-metadata-keys-request.schema.json
@@ -8,5 +8,6 @@
       "description": "The message identifier used to match server response to the request"
     }
   },
+  "required": [ "id" ],
   "additionalProperties": false
 }

--- a/0010-endpoint-metadata-extension/schemas/get-metadata-keys-response.schema.json
+++ b/0010-endpoint-metadata-extension/schemas/get-metadata-keys-response.schema.json
@@ -29,6 +29,7 @@
     }
   },
   "required": [
+    "id",
     "statusCode",
     "reasonPhrase"
   ],

--- a/0010-endpoint-metadata-extension/schemas/get-metadata-request.schema.json
+++ b/0010-endpoint-metadata-extension/schemas/get-metadata-request.schema.json
@@ -18,5 +18,6 @@
       "description": "The metadata keys to be returned. Optional, if not specified all metadata keys will be returned"
     }
   },
+  "required": [ "id" ],
   "additionalProperties": false
 }

--- a/0010-endpoint-metadata-extension/schemas/get-metadata-response.schema.json
+++ b/0010-endpoint-metadata-extension/schemas/get-metadata-response.schema.json
@@ -27,6 +27,7 @@
     }
   },
   "required": [
+    "id",
     "statusCode",
     "reasonPhrase"
   ],

--- a/0010-endpoint-metadata-extension/schemas/update-metadata-request.schema.json
+++ b/0010-endpoint-metadata-extension/schemas/update-metadata-request.schema.json
@@ -14,7 +14,7 @@
         "\\S": {}
       },
       "additionalProperties": false,
-      "description": "The endpoint metadata object. The property names of this object are metadata keys and values of these properties are values"
+      "description": "The endpoint metadata object. The property names of this object are metadata keys and values of these properties are metadata values"
     }
   },
   "additionalProperties": false,

--- a/0010-endpoint-metadata-extension/schemas/update-metadata-response.schema.json
+++ b/0010-endpoint-metadata-extension/schemas/update-metadata-response.schema.json
@@ -19,6 +19,7 @@
     }
   },
   "required": [
+    "id",
     "statusCode",
     "reasonPhrase"
   ],

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ RFCs can be in raw, draft, stable, deprecated, or retired status.
 | [5/CMX](0005-configuration-management-extension/README.md) | Configuration Management Extension protocol | Raw    |
 | [6/CMX2CDP](0006-cmx2cdp-protocol/README.md)               | CMX to CDP protocol                         | Raw    |
 | [7/CMX](0007-configuration-management-extension/README.md) | Configuration Management Extension          | Raw    |
-| [9/EPEIPC](0009-endpoint-events-ipc/README.md)              | Endpoint events IPC                         | Draft  |
+| [9/EPEIPC](0009-endpoint-events-ipc/README.md)             | Endpoint events IPC                         | Draft  |
+| [10/EPMDX](0010-endpoint-metadata-extension/README.md)     | Endpoint Metadata Extension protocol        | Draft  |
 
 # Change process
 


### PR DESCRIPTION
The resource path is a slightly different beast than MQTT topic
name. Resource path is defined in 1/KP and is an abstraction for
hiding MQTT/CoAP differences. When we talk about request/response, the
resource path is the same for both requests and responses, MQTT topic
names are different, and CoAP `URI-Path`s are equal. `/status`
appending is MQTT-specific and 1/KP extensions should be independ from
underlying 1/KP protocol, so I removed that part.

Recent additions standardize the meaning of request `id` field, so I
adapt this protocol to the new conventions.

Also, fix some grammar, remove TOC (as it will be auto-generated), and
add 10/EPMDX to the RFC index.